### PR TITLE
fix: Review 엔티티에서 중복 reviewCount 필드 제거

### DIFF
--- a/src/main/java/com/likelion/hufjok/DTO/ReviewCreateRequestDto.java
+++ b/src/main/java/com/likelion/hufjok/DTO/ReviewCreateRequestDto.java
@@ -9,5 +9,4 @@ public class ReviewCreateRequestDto {
     private Long materialId;
     private String comment;
     private int rating;
-    private int reviewCount;
 }

--- a/src/main/java/com/likelion/hufjok/DTO/ReviewCreateResponseDto.java
+++ b/src/main/java/com/likelion/hufjok/DTO/ReviewCreateResponseDto.java
@@ -8,16 +8,14 @@ public record ReviewCreateResponseDto(
         String authorNickname,
         Integer rating,
         String comment,
-        int reviewCount,
         LocalDateTime createdAt
 ) {
     public static ReviewCreateResponseDto from(Review review) {
         return new ReviewCreateResponseDto(
                 review.getId(),
-                review.getUser().getNickname(), // User 엔티티에서 닉네임 가져오기
+                review.getUser().getNickname(),
                 review.getRating(),
                 review.getComment(),
-                review.getReviewCount(),
                 review.getCreatedAt()
         );
     }

--- a/src/main/java/com/likelion/hufjok/DTO/ReviewGetResponseDto.java
+++ b/src/main/java/com/likelion/hufjok/DTO/ReviewGetResponseDto.java
@@ -12,7 +12,6 @@ public class ReviewGetResponseDto {
     private final int rating;
     private final String comment;
     private final LocalDateTime createdAt;
-    private final int reviewCount;
     private final boolean isAuthor;
 
     public ReviewGetResponseDto(Review review, boolean isAuthor) {
@@ -22,7 +21,6 @@ public class ReviewGetResponseDto {
         this.rating = review.getRating();
         this.comment = review.getComment();
         this.createdAt = review.getCreatedAt();
-        this.reviewCount = review.getReviewCount();
         this.isAuthor = isAuthor;
     }
 }

--- a/src/main/java/com/likelion/hufjok/domain/Review.java
+++ b/src/main/java/com/likelion/hufjok/domain/Review.java
@@ -21,8 +21,6 @@ public class Review {
 
     private String comment;
 
-    private int reviewCount = 0;
-
     @Column(nullable = false, updatable = false)
     @CreationTimestamp
     private LocalDateTime createdAt;
@@ -39,8 +37,4 @@ public class Review {
     @JoinColumn(name = "material_id", nullable = false)
     @JsonIgnore
     private Material material;
-
-    public void increaseReviewCount() {
-        this.reviewCount++;
-    }
 }

--- a/src/main/java/com/likelion/hufjok/service/ReviewService.java
+++ b/src/main/java/com/likelion/hufjok/service/ReviewService.java
@@ -34,17 +34,13 @@ public class ReviewService {
         Material material = materialRepository.findById(materialId)
                 .orElseThrow(() -> new IllegalArgumentException("Material not found"));
 
-        long existingCount = reviewRepository.countByMaterialId(materialId);
-
         Review review = Review.builder()
                 .rating(request.getRating())
                 .comment(request.getComment())
                 .user(user)
                 .material(material)
-                .reviewCount((int) existingCount + 1)
                 .build();
 
-        review.increaseReviewCount(); // 현재 리뷰 객체의 count +1
         Review savedReview = reviewRepository.save(review);
 
         return ReviewCreateResponseDto.from(savedReview);


### PR DESCRIPTION
- Review.reviewCount 필드 제거 (Material의 reviews.size()로 계산)
- ReviewService에서 중복 카운트 로직 제거
- ReviewCreateResponseDto, ReviewGetResponseDto에서 reviewCount 제거
- 리뷰 1개 작성 시 2개로 표시되던 버그 수정